### PR TITLE
Added ability for http headers to be provided (with Nil default)

### DIFF
--- a/src/main/scala/me/maciejb/etcd/client/EtcdClient.scala
+++ b/src/main/scala/me/maciejb/etcd/client/EtcdClient.scala
@@ -1,11 +1,13 @@
 package me.maciejb.etcd.client
 
 import akka.actor.{ActorSystem, Cancellable}
+import akka.http.scaladsl.model.HttpHeader
 import akka.http.scaladsl.settings.ClientConnectionSettings
 import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import me.maciejb.etcd.client.impl.EtcdClientImpl
 
+import scala.collection.immutable
 import scala.concurrent.{ExecutionContext, Future}
 
 /**
@@ -69,10 +71,11 @@ object EtcdClient {
     * @param httpClientSettings optional client options for Akka HTTP.
     */
   def apply(host: String, port: Int = DefaultPort,
-            httpClientSettings: Option[ClientConnectionSettings] = None)
+            httpClientSettings: Option[ClientConnectionSettings] = None,
+            httpHeaders: immutable.Seq[HttpHeader] = Nil)
            (implicit ec: ExecutionContext,
             system: ActorSystem,
             mat: Materializer): EtcdClient =
-    new EtcdClientImpl(host, port, httpClientSettings)
+    new EtcdClientImpl(host, port, httpClientSettings, httpHeaders)
 
 }

--- a/src/main/scala/me/maciejb/etcd/client/impl/EtcdClientImpl.scala
+++ b/src/main/scala/me/maciejb/etcd/client/impl/EtcdClientImpl.scala
@@ -16,13 +16,15 @@ import akka.util.ByteString
 import me.maciejb.etcd.client.{EtcdClient, EtcdError, EtcdResponse}
 import spray.json._
 
+import scala.collection.immutable
 import scala.concurrent.{ExecutionContext, Future}
 
 /**
   * `etcd` client implementation.
   */
 private[client] class EtcdClientImpl(host: String, port: Int = 4001,
-                                     httpClientSettings: Option[ClientConnectionSettings] = None)
+                                     httpClientSettings: Option[ClientConnectionSettings] = None,
+                                     httpHeaders: immutable.Seq[HttpHeader] = Nil)
                                     (implicit ec: ExecutionContext,
                                      system: ActorSystem,
                                      mat: Materializer) extends EtcdClient {
@@ -155,9 +157,9 @@ private[client] class EtcdClientImpl(host: String, port: Int = 4001,
 
   private def call(method: HttpMethod, key: String, params: Option[(String, String)]*): Future[EtcdResponse] =
     run(if (method == GET || method == DELETE) {
-      HttpRequest(method, Uri(path = keyPath(key)).withQuery(mkQuery(params.toSeq)))
+      HttpRequest(method, Uri(path = keyPath(key)).withQuery(mkQuery(params.toSeq)), headers = httpHeaders)
     } else {
-      HttpRequest(method, Uri(path = keyPath(key)), entity = mkEntity(params.toSeq))
+      HttpRequest(method, Uri(path = keyPath(key)), entity = mkEntity(params.toSeq), headers = httpHeaders)
     })
 
 }


### PR DESCRIPTION
I'm using this for authentication by passing in a predefined akka http basic auth header a la

`val authHeader = List(headers.Authorization(BasicHttpCredentials("user", "pass")))`
`private val etcdClient = EtcdClient(settings.host, settings.port, httpHeaders = authHeader)`

but it can potentially be used to pass other headers as well.
