### PR TITLE
Added SSL capability

### DIFF
--- a/src/main/scala/me/maciejb/etcd/client/EtcdClient.scala
+++ b/src/main/scala/me/maciejb/etcd/client/EtcdClient.scala
@@ -72,10 +72,11 @@ object EtcdClient {
     */
   def apply(host: String, port: Int = DefaultPort,
             httpClientSettings: Option[ClientConnectionSettings] = None,
-            httpHeaders: immutable.Seq[HttpHeader] = Nil)
+            httpHeaders: immutable.Seq[HttpHeader] = Nil,
+            sslEnabled: Boolean = false)
            (implicit ec: ExecutionContext,
             system: ActorSystem,
             mat: Materializer): EtcdClient =
-    new EtcdClientImpl(host, port, httpClientSettings, httpHeaders)
+    new EtcdClientImpl(host, port, httpClientSettings, httpHeaders, sslEnabled)
 
 }

--- a/src/main/scala/me/maciejb/etcd/client/EtcdClient.scala
+++ b/src/main/scala/me/maciejb/etcd/client/EtcdClient.scala
@@ -1,11 +1,13 @@
 package me.maciejb.etcd.client
 
 import akka.actor.{ActorSystem, Cancellable}
+import akka.http.scaladsl.model.HttpHeader
 import akka.http.scaladsl.settings.ClientConnectionSettings
 import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import me.maciejb.etcd.client.impl.EtcdClientImpl
 
+import scala.collection.immutable
 import scala.concurrent.{ExecutionContext, Future}
 
 /**
@@ -69,10 +71,11 @@ object EtcdClient {
     * @param httpClientSettings optional client options for Akka HTTP.
     */
   def apply(host: String, port: Int = DefaultPort,
-            httpClientSettings: Option[ClientConnectionSettings] = None)
+            httpClientSettings: Option[ClientConnectionSettings] = None,
+            httpHeaders: immutable.Seq[HttpHeader] = Nil)
            (implicit ec: ExecutionContext,
             system: ActorSystem,
             mat: Materializer): EtcdClient =
-    new EtcdClientImpl(host, port, httpClientSettings)
+    new EtcdClientImpl(host, port, httpClientSettings, httpHeaders)
 
 }

--- a/src/main/scala/me/maciejb/etcd/client/impl/EtcdClientImpl.scala
+++ b/src/main/scala/me/maciejb/etcd/client/impl/EtcdClientImpl.scala
@@ -16,13 +16,15 @@ import akka.util.ByteString
 import me.maciejb.etcd.client.{EtcdClient, EtcdError, EtcdResponse}
 import spray.json._
 
+import scala.collection.immutable
 import scala.concurrent.{ExecutionContext, Future}
 
 /**
   * `etcd` client implementation.
   */
 private[client] class EtcdClientImpl(host: String, port: Int = 4001,
-                                     httpClientSettings: Option[ClientConnectionSettings] = None)
+                                     httpClientSettings: Option[ClientConnectionSettings] = None,
+                                     httpHeaders: immutable.Seq[HttpHeader] = Nil)
                                     (implicit ec: ExecutionContext,
                                      system: ActorSystem,
                                      mat: Materializer) extends EtcdClient {
@@ -155,9 +157,9 @@ private[client] class EtcdClientImpl(host: String, port: Int = 4001,
 
   private def call(method: HttpMethod, key: String, params: Option[(String, String)]*): Future[EtcdResponse] =
     run(if (method == GET || method == DELETE) {
-      HttpRequest(method, Uri(path = keyPath(key)).withQuery(mkQuery(params.toSeq)))
+      HttpRequest(method, Uri(path = keyPath(key)).withQuery(mkQuery(params.toSeq)), headers = httpHeaders)
     } else {
-      HttpRequest(method, Uri(path = keyPath(key)), entity = mkEntity(params.toSeq))
+      HttpRequest(method, Uri(path = keyPath(key)), entity = mkEntity(params.toSeq), headers = httpHeaders)
     })
 
 }


### PR DESCRIPTION
When SSL cert is given through typical akka ssl-config, SSL may be enabled for the etcd client.

(This is branched off of the HTTP header branch, please let me know if you'd like a separate branch off master.)
